### PR TITLE
Fix client initialization to avoid unsafe client references

### DIFF
--- a/src/main/java/com/mishkis/orbitalrailgun/ForgeOrbitalRailgunMod.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/ForgeOrbitalRailgunMod.java
@@ -3,14 +3,11 @@ package com.mishkis.orbitalrailgun;
 import com.mishkis.orbitalrailgun.net.NetworkHandler;
 import com.mishkis.orbitalrailgun.registry.ModItems;
 import com.mishkis.orbitalrailgun.util.OrbitalRailgunStrikeManager;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,18 +21,10 @@ public final class ForgeOrbitalRailgunMod {
         final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
         ModItems.REGISTER.register(modBus);
 
-        modBus.addListener(this::onClientSetup);
-
         MinecraftForge.EVENT_BUS.register(this);
 
         NetworkHandler.init();
         OrbitalRailgunStrikeManager.initialize();
-
-        DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> com.mishkis.orbitalrailgun.client.ClientInit::register);
-    }
-
-    private void onClientSetup(final FMLClientSetupEvent event) {
-        DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> () -> com.mishkis.orbitalrailgun.client.ClientInit.onClientSetup(event));
     }
 
     @SubscribeEvent

--- a/src/main/java/com/mishkis/orbitalrailgun/client/ClientInit.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/ClientInit.java
@@ -6,10 +6,10 @@ import com.mishkis.orbitalrailgun.client.render.railgun.PostChainManager;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
-import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod.EventBusSubscriber(modid = ForgeOrbitalRailgunMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public final class ClientInit {
@@ -19,18 +19,13 @@ public final class ClientInit {
     private ClientInit() {
     }
 
-    public static void register() {
-        final IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
-        modBus.addListener(ClientInit::onRegisterReloadListeners);
-    }
-
+    @SubscribeEvent
     public static void onClientSetup(final FMLClientSetupEvent event) {
-        event.enqueueWork(() -> {
-            // Client events are registered via static subscribers.
-        });
+        event.enqueueWork(() -> MinecraftForge.EVENT_BUS.register(new ClientEvents()));
     }
 
-    private static void onRegisterReloadListeners(final RegisterClientReloadListenersEvent event) {
+    @SubscribeEvent
+    public static void onRegisterReloadListeners(final RegisterClientReloadListenersEvent event) {
         event.registerReloadListener(WORLD_POST);
         event.registerReloadListener(GUI_POST);
     }

--- a/src/main/java/com/mishkis/orbitalrailgun/client/event/ClientEvents.java
+++ b/src/main/java/com/mishkis/orbitalrailgun/client/event/ClientEvents.java
@@ -5,26 +5,22 @@ import com.mishkis.orbitalrailgun.item.OrbitalRailgunItem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.util.Mth;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGuiEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.client.event.ViewportEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-
-@Mod.EventBusSubscriber(value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class ClientEvents {
 
     @SubscribeEvent
-    public static void onClientTick(final TickEvent.ClientTickEvent event) {
+    public void onClientTick(final TickEvent.ClientTickEvent event) {
         if (event.phase == TickEvent.Phase.END) {
             RailgunClientState.get().clientTick(Minecraft.getInstance());
         }
     }
 
     @SubscribeEvent
-    public static void onComputeFov(final ViewportEvent.ComputeFov event) {
+    public void onComputeFov(final ViewportEvent.ComputeFov event) {
         final RailgunClientState state = RailgunClientState.get();
         if (state.isCharging() || state.isAwaitingAck()) {
             event.setFOV(Minecraft.getInstance().options.fov().get());
@@ -32,7 +28,7 @@ public final class ClientEvents {
     }
 
     @SubscribeEvent
-    public static void onRenderLevelStage(final RenderLevelStageEvent event) {
+    public void onRenderLevelStage(final RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_LEVEL) {
             return;
         }
@@ -43,7 +39,7 @@ public final class ClientEvents {
     }
 
     @SubscribeEvent
-    public static void onRenderGui(final RenderGuiEvent.Post event) {
+    public void onRenderGui(final RenderGuiEvent.Post event) {
         final RailgunClientState state = RailgunClientState.get();
         if (!state.shouldRenderGuiEffect()) {
             return;


### PR DESCRIPTION
## Summary
- remove client-only DistExecutor usage from the common mod entrypoint
- move client setup into a dedicated ClientInit subscriber that registers reload listeners and client event handlers

## Testing
- ⚠️ `./gradlew build` *(aborted: forge dependency downloads exceeded time limits in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e035c2a5188325a800ff7d9a89d625